### PR TITLE
Fix OneHotEncoder compatibility and add tutorial notebook

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -1,0 +1,368 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7420c7b9",
+   "metadata": {},
+   "source": [
+    "# Краткое руководство по Policyscope\n",
+    "Policyscope позволяет оценивать новые рекомендательные политики на основе логов\n",
+    "существующей политики. Здесь мы на синтетических данных сравним политику B\n",
+    "с текущей политикой A."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69f8f98",
+   "metadata": {},
+   "source": [
+    "## Алгоритмы и допущения\n",
+    "- **Replay** — усредняет отклики только по тем случаям, где действия A и B совпали. Требует значительного пересечения действий.\n",
+    "- **IPS** — взвешивает записи по отношению вероятностей \\pi_B/\\pi_A. Нужны корректные пропенсити и ненулевой шанс всех действий.\n",
+    "- **SNIPS** — нормализует веса IPS, снижая дисперсию.\n",
+    "- **DM** — строит модель отклика \\hat{\\mu}(x,a). Предполагается правильная спецификация модели.\n",
+    "- **DR** — объединяет DM и IPS и остаётся несмещённым, если верна хотя бы одна часть."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "543bcf64",
+   "metadata": {},
+   "source": [
+    "## Формат данных\n",
+    "Логи политики A должны содержать столбцы: `user_id`, `a_A`, `propensity_A`, `accept`, `cltv` и признаки `loyal`, `age_z`, `risk_z`, `income_z`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc05d32d",
+   "metadata": {},
+   "source": [
+    "## Генерация синтетики и сравнение политик"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ebc3eed4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-18T15:29:31.526917Z",
+     "iopub.status.busy": "2025-08-18T15:29:31.526573Z",
+     "iopub.status.idle": "2025-08-18T15:29:33.687824Z",
+     "shell.execute_reply": "2025-08-18T15:29:33.686309Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "from policyscope.synthetic import SynthConfig, SyntheticRecommenderEnv\n",
+    "from policyscope.policies import make_policy\n",
+    "from policyscope.estimators import (\n",
+    "    value_on_policy, replay_value, prepare_piB_taken,\n",
+    "    ips_value, snips_value, dm_value, dr_value, train_mu_hat,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1fa02051",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-18T15:29:33.692888Z",
+     "iopub.status.busy": "2025-08-18T15:29:33.692344Z",
+     "iopub.status.idle": "2025-08-18T15:29:34.496072Z",
+     "shell.execute_reply": "2025-08-18T15:29:34.494375Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>loyal</th>\n",
+       "      <th>age</th>\n",
+       "      <th>risk</th>\n",
+       "      <th>income</th>\n",
+       "      <th>region</th>\n",
+       "      <th>age_z</th>\n",
+       "      <th>risk_z</th>\n",
+       "      <th>income_z</th>\n",
+       "      <th>a_A</th>\n",
+       "      <th>propensity_A</th>\n",
+       "      <th>accept</th>\n",
+       "      <th>cltv</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>35</td>\n",
+       "      <td>0.501541</td>\n",
+       "      <td>14575.147294</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-0.416667</td>\n",
+       "      <td>0.006164</td>\n",
+       "      <td>-1.842693</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.925</td>\n",
+       "      <td>1</td>\n",
+       "      <td>240.092667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>29</td>\n",
+       "      <td>0.732395</td>\n",
+       "      <td>26513.050864</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-0.916667</td>\n",
+       "      <td>0.929582</td>\n",
+       "      <td>-0.646610</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.925</td>\n",
+       "      <td>1</td>\n",
+       "      <td>826.611167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>45</td>\n",
+       "      <td>0.188225</td>\n",
+       "      <td>22144.013597</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.416667</td>\n",
+       "      <td>-1.247099</td>\n",
+       "      <td>-1.006583</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.925</td>\n",
+       "      <td>0</td>\n",
+       "      <td>189.567727</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>52</td>\n",
+       "      <td>0.443791</td>\n",
+       "      <td>38523.334086</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>-0.224838</td>\n",
+       "      <td>0.100297</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.925</td>\n",
+       "      <td>0</td>\n",
+       "      <td>305.824421</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>31</td>\n",
+       "      <td>0.532530</td>\n",
+       "      <td>24493.569649</td>\n",
+       "      <td>3</td>\n",
+       "      <td>-0.750000</td>\n",
+       "      <td>0.130121</td>\n",
+       "      <td>-0.804989</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.925</td>\n",
+       "      <td>0</td>\n",
+       "      <td>623.350392</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   user_id  loyal  age      risk        income  region     age_z    risk_z  \\\n",
+       "0        0      0   35  0.501541  14575.147294       1 -0.416667  0.006164   \n",
+       "1        1      1   29  0.732395  26513.050864       2 -0.916667  0.929582   \n",
+       "2        2      0   45  0.188225  22144.013597       0  0.416667 -1.247099   \n",
+       "3        3      0   52  0.443791  38523.334086       4  1.000000 -0.224838   \n",
+       "4        4      1   31  0.532530  24493.569649       3 -0.750000  0.130121   \n",
+       "\n",
+       "   income_z  a_A  propensity_A  accept        cltv  \n",
+       "0 -1.842693    2         0.925       1  240.092667  \n",
+       "1 -0.646610    2         0.925       1  826.611167  \n",
+       "2 -1.006583    1         0.925       0  189.567727  \n",
+       "3  0.100297    1         0.925       0  305.824421  \n",
+       "4 -0.804989    2         0.925       0  623.350392  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "cfg = SynthConfig(n_users=5000, horizon_days=30, seed=42)\n",
+    "env = SyntheticRecommenderEnv(cfg)\n",
+    "X = env.sample_users()\n",
+    "policyA = make_policy('epsilon_greedy', epsilon=0.1, seed=0)\n",
+    "policyB = make_policy('softmax', tau=0.7, seed=1)\n",
+    "logsA = env.simulate_logs_A(policyA, X)\n",
+    "logsA.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5e0bd7d8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-18T15:29:34.500622Z",
+     "iopub.status.busy": "2025-08-18T15:29:34.500155Z",
+     "iopub.status.idle": "2025-08-18T15:29:35.546465Z",
+     "shell.execute_reply": "2025-08-18T15:29:35.545025Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Оценка V(B)</th>\n",
+       "      <th>ATE</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Replay</th>\n",
+       "      <td>0.420945</td>\n",
+       "      <td>-0.051055</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>IPS</th>\n",
+       "      <td>0.461673</td>\n",
+       "      <td>-0.010327</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SNIPS</th>\n",
+       "      <td>0.519345</td>\n",
+       "      <td>0.047345</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DM</th>\n",
+       "      <td>0.488425</td>\n",
+       "      <td>0.016425</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>DR</th>\n",
+       "      <td>0.523130</td>\n",
+       "      <td>0.051130</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Оценка V(B)       ATE\n",
+       "Replay     0.420945 -0.051055\n",
+       "IPS        0.461673 -0.010327\n",
+       "SNIPS      0.519345  0.047345\n",
+       "DM         0.488425  0.016425\n",
+       "DR         0.523130  0.051130"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Истинный V(A) = 0.461, V(B) = 0.533, ATE = 0.072\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "V_A = value_on_policy(logsA, target='accept')\n",
+    "a_B = policyB.action_argmax(X)\n",
+    "V_replay = replay_value(logsA, a_B, target='accept')\n",
+    "piB_taken = prepare_piB_taken(logsA, policyB)\n",
+    "mu_accept = train_mu_hat(logsA, target='accept')\n",
+    "V_ips, ess_ips, clip_ips = ips_value(logsA, piB_taken, target='accept', weight_clip=20)\n",
+    "V_snips, ess_snips, clip_snips = snips_value(logsA, piB_taken, target='accept', weight_clip=20)\n",
+    "V_dm = dm_value(logsA, policyB, mu_accept, target='accept')\n",
+    "V_dr, ess_dr, clip_dr = dr_value(logsA, policyB, mu_accept, target='accept', weight_clip=20)\n",
+    "V_A_true = env.oracle_value(policyA, X, metric='accept')\n",
+    "V_B_true = env.oracle_value(policyB, X, metric='accept')\n",
+    "res = pd.DataFrame({'Оценка V(B)': [V_replay, V_ips, V_snips, V_dm, V_dr]}, index=['Replay','IPS','SNIPS','DM','DR'])\n",
+    "res['ATE'] = res['Оценка V(B)'] - V_A\n",
+    "display(res)\n",
+    "print(f'Истинный V(A) = {V_A_true:.3f}, V(B) = {V_B_true:.3f}, ATE = {V_B_true - V_A_true:.3f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf08af9c",
+   "metadata": {},
+   "source": [
+    "### Ссылки\n",
+    "- Евгений Ян. [Counterfactual Evaluation for Recommendation Systems](https://eugeneyan.com/writing/offline-recsys/)\n",
+    "- Farajtabar et al. *More Robust Doubly Robust Off-policy Evaluation* (2022)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/policyscope/estimators.py
+++ b/src/policyscope/estimators.py
@@ -80,14 +80,21 @@ def make_design(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, OneHotEncoder
     """
     X_base = df[["loyal", "age_z", "risk_z", "income_z"]].values
     a = df["a_A"].values.reshape(-1, 1)
-    oh = OneHotEncoder(categories='auto', sparse=False, handle_unknown='ignore')
+    try:
+        oh = OneHotEncoder(
+            categories="auto", sparse_output=False, handle_unknown="ignore"
+        )
+    except TypeError:  # scikit-learn < 1.2
+        oh = OneHotEncoder(
+            categories="auto", sparse=False, handle_unknown="ignore"
+        )
     A_oh = oh.fit_transform(a)
     X = np.hstack([X_base, A_oh])
     return X, A_oh, oh
 
 
 def train_mu_hat(df: pd.DataFrame, target: Literal["accept", "cltv"] = "accept"):
-    """Обучает модель исхода \(\hat\mu(x,a)\).
+    r"""Обучает модель исхода \(\hat\mu(x,a)\).
 
     Для бинарного таргета `accept` используется логистическая регрессия.
     Для вещественного `cltv` — линейная регрессия.
@@ -107,7 +114,7 @@ def train_mu_hat(df: pd.DataFrame, target: Literal["accept", "cltv"] = "accept")
 
 
 def mu_hat_predict(model, df: pd.DataFrame, action: np.ndarray, target: str) -> np.ndarray:
-    """Предсказывает \(\hat\mu(x,a)\) для заданного действия.
+    r"""Предсказывает \(\hat\mu(x,a)\) для заданного действия.
 
     Параметр `action` может быть массивом тех же размеров, что и `df`, или
     скалярным значением (будет вещательно расширён).

--- a/src/policyscope/policies.py
+++ b/src/policyscope/policies.py
@@ -38,9 +38,11 @@ __all__ = [
 
 class BasePolicy:
     """Базовый класс политики. Должен реализовать `action_probs(X)`.
-    
+
     Метод `action_argmax` вычисляет индекс действия с максимальной вероятностью.
     """
+
+    ACTIONS = np.array([0, 1, 2, 3], dtype=int)
 
     def action_probs(self, X: pd.DataFrame) -> np.ndarray:
         raise NotImplementedError

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,0 +1,29 @@
+import numpy as np
+from policyscope.synthetic import SynthConfig, SyntheticRecommenderEnv
+from policyscope.policies import make_policy
+from policyscope.estimators import (
+    train_mu_hat,
+    prepare_piB_taken,
+    ips_value,
+    snips_value,
+    dr_value,
+)
+
+
+def test_estimators_run_on_synthetic():
+    cfg = SynthConfig(n_users=100, horizon_days=30, seed=0)
+    env = SyntheticRecommenderEnv(cfg)
+    X = env.sample_users()
+    policyA = make_policy("epsilon_greedy", epsilon=0.1, seed=0)
+    logsA = env.simulate_logs_A(policyA, X)
+    policyB = make_policy("softmax", tau=0.7, seed=1)
+    piB_taken = prepare_piB_taken(logsA, policyB)
+    mu_accept = train_mu_hat(logsA, target="accept")
+    v_ips, ess, _ = ips_value(logsA, piB_taken, target="accept", weight_clip=20)
+    v_snips, _, _ = snips_value(logsA, piB_taken, target="accept", weight_clip=20)
+    v_dr, _, _ = dr_value(logsA, policyB, mu_accept, target="accept", weight_clip=20)
+
+    assert np.isfinite(v_ips)
+    assert np.isfinite(v_snips)
+    assert np.isfinite(v_dr)
+    assert ess > 0


### PR DESCRIPTION
## Summary
- handle scikit-learn >=1.2 OneHotEncoder `sparse_output` with fallback
- expose action space on policies for DR estimator
- add synthetic integration test and a worked tutorial notebook

## Testing
- `pytest`
- `python examples/run_synthetic_experiment.py --n_users 1000 --seed 0 --policyA epsilon_greedy --epsilon 0.1 --policyB softmax --tau 0.7 --horizon 30 --weight_clip 20`


------
https://chatgpt.com/codex/tasks/task_e_68a34484e2048332950bf5469af995cd