### PR TITLE
Add validation for propensity and improve error tests

### DIFF
--- a/src/policyscope/estimators.py
+++ b/src/policyscope/estimators.py
@@ -19,6 +19,7 @@ policyscope.estimators
 
 from __future__ import annotations
 
+import logging
 import numpy as np
 import pandas as pd
 from typing import Tuple, Optional, Literal
@@ -39,6 +40,32 @@ __all__ = [
     "dr_value",
     "ate_from_values",
 ]
+
+
+def _validate_logs(df: pd.DataFrame, target: str, warn: bool = False) -> None:
+    """Проверяет наличие необходимых колонок и корректность `propensity_A`.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Логи политики A.
+    target : str
+        Имя целевой метрики.
+    warn : bool, default False
+        Логировать предупреждение при некорректных значениях `propensity_A`.
+    """
+    required = {"a_A", "propensity_A", target}
+    missing = required - set(df.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"Missing required columns: {missing_str}")
+
+    pA = df["propensity_A"].values
+    invalid = (pA <= 0) | (pA > 1)
+    if np.any(invalid):
+        if warn:
+            logging.warning("propensity_A outside (0,1] range")
+        raise ValueError("propensity_A must be in (0,1]")
 
 
 def ess(weights: np.ndarray) -> float:
@@ -189,7 +216,8 @@ def ips_value(df: pd.DataFrame, piB_taken: np.ndarray, target: str = "accept", w
     (value, ess, clip_share)
         Оценка метрики, эффективный размер выборки и доля обрезанных весов.
     """
-    pA = np.clip(df["propensity_A"].values, 1e-12, None)
+    _validate_logs(df, target, warn=True)
+    pA = df["propensity_A"].values
     w = piB_taken / pA
     clip_share = 0.0
     if weight_clip is not None:
@@ -207,7 +235,8 @@ def snips_value(df: pd.DataFrame, piB_taken: np.ndarray, target: str = "accept",
 
     Считается как (∑r_i w_i)/(∑w_i). Применяет обрезку весов, если указано.
     """
-    pA = np.clip(df["propensity_A"].values, 1e-12, None)
+    _validate_logs(df, target, warn=False)
+    pA = df["propensity_A"].values
     w = piB_taken / pA
     clip_share = 0.0
     if weight_clip is not None:
@@ -237,13 +266,14 @@ def dm_value(df: pd.DataFrame, policyB, mu_model, target: str = "accept") -> flo
 def dr_value(df: pd.DataFrame, policyB, mu_model, target: str = "accept", weight_clip: Optional[float] = None) -> Tuple[float, float, float]:
     """Doubly Robust оценка значения новой политики.
 
-    Комбинирует Direct Method и IPS‑поправку. При корректном 
+    Комбинирует Direct Method и IPS‑поправку. При корректном
     моделировании хотя бы одной составляющей даёт несмещённую оценку.
     """
+    _validate_logs(df, target, warn=True)
     probsB = policyB.action_probs(df)
     r = df[target].values
     aA = df["a_A"].values
-    pA = np.clip(df["propensity_A"].values, 1e-12, None)
+    pA = df["propensity_A"].values
 
     # DM‑часть: ожидание модели
     dm_part = np.zeros(len(df), dtype=float)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pandas as pd
+import pytest
 from policyscope.synthetic import SynthConfig, SyntheticRecommenderEnv
 from policyscope.policies import make_policy
 from policyscope.estimators import (
@@ -27,3 +29,16 @@ def test_estimators_run_on_synthetic():
     assert np.isfinite(v_snips)
     assert np.isfinite(v_dr)
     assert ess > 0
+
+
+def test_invalid_inputs_raise_errors():
+    df = pd.DataFrame({"a_A": [0], "propensity_A": [1.2], "accept": [1]})
+    piB = np.array([1.0])
+    with pytest.raises(ValueError):
+        ips_value(df, piB, target="accept")
+
+    df_missing = pd.DataFrame({"propensity_A": [0.5], "accept": [1]})
+    dummy_policy = type("P", (), {"action_probs": lambda self, d: np.ones((len(d), 1))})()
+    dummy_model = object()
+    with pytest.raises(ValueError):
+        dr_value(df_missing, dummy_policy, dummy_model, target="accept")


### PR DESCRIPTION
## Summary
- Validate logs for required columns and propensity_A range
- Warn and raise ValueError in IPS and DR estimators when propensity_A invalid
- Add tests for invalid input data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a35f30655083328b0a4cf7aaaeca15