### PR TITLE
Model propensities from features

### DIFF
--- a/src/policyscope/synthetic.py
+++ b/src/policyscope/synthetic.py
@@ -230,27 +230,25 @@ class SyntheticRecommenderEnv:
         Параметры
         ----------
         policyA : объект политики
-            Политика, генерирующая действие и пропенсити.
+            Политика, генерирующая действие.
         X : pd.DataFrame
             Данные пользователей.
 
         Returns
         -------
         pd.DataFrame
-            Логи со столбцами: a_A, propensity_A, accept, cltv + исходные признаки.
+            Логи со столбцами: a_A, accept, cltv + исходные признаки.
         """
         probs = policyA.action_probs(X)
         a = np.array([
             self.rng.choice(self.ACTIONS, p=probs[i])
             for i in range(len(X))
         ], dtype=int)
-        prop = probs[np.arange(len(X)), a]
         p_accept = self.true_accept_prob(X, a)
         acc = self.draw_accept(p_accept)
         cltv = self.draw_cltv(X, a, acc)
         df = X.copy()
         df["a_A"] = a
-        df["propensity_A"] = prop
         df["accept"] = acc
         df["cltv"] = cltv
         return df

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -4,6 +4,8 @@ import pytest
 from policyscope.synthetic import SynthConfig, SyntheticRecommenderEnv
 from policyscope.policies import make_policy
 from policyscope.estimators import (
+    train_pi_hat,
+    pi_hat_predict,
     train_mu_hat,
     prepare_piB_taken,
     ips_value,
@@ -20,10 +22,13 @@ def test_estimators_run_on_synthetic():
     logsA = env.simulate_logs_A(policyA, X)
     policyB = make_policy("softmax", tau=0.7, seed=1)
     piB_taken = prepare_piB_taken(logsA, policyB)
+    pi_model = train_pi_hat(logsA)
+    pA_all = pi_hat_predict(pi_model, logsA)
+    pA_taken = pA_all[np.arange(len(logsA)), logsA["a_A"].values]
     mu_accept = train_mu_hat(logsA, target="accept")
-    v_ips, ess, _ = ips_value(logsA, piB_taken, target="accept", weight_clip=20)
-    v_snips, _, _ = snips_value(logsA, piB_taken, target="accept", weight_clip=20)
-    v_dr, _, _ = dr_value(logsA, policyB, mu_accept, target="accept", weight_clip=20)
+    v_ips, ess, _ = ips_value(logsA, piB_taken, pA_taken, target="accept", weight_clip=20)
+    v_snips, _, _ = snips_value(logsA, piB_taken, pA_taken, target="accept", weight_clip=20)
+    v_dr, _, _ = dr_value(logsA, policyB, mu_accept, pA_taken, target="accept", weight_clip=20)
 
     assert np.isfinite(v_ips)
     assert np.isfinite(v_snips)
@@ -32,13 +37,15 @@ def test_estimators_run_on_synthetic():
 
 
 def test_invalid_inputs_raise_errors():
-    df = pd.DataFrame({"a_A": [0], "propensity_A": [1.2], "accept": [1]})
+    df = pd.DataFrame({"a_A": [0], "accept": [1]})
     piB = np.array([1.0])
+    pA = np.array([1.2])
     with pytest.raises(ValueError):
-        ips_value(df, piB, target="accept")
+        ips_value(df, piB, pA, target="accept")
 
-    df_missing = pd.DataFrame({"propensity_A": [0.5], "accept": [1]})
+    df_missing = pd.DataFrame({"accept": [1]})
+    pA2 = np.array([0.5])
     dummy_policy = type("P", (), {"action_probs": lambda self, d: np.ones((len(d), 1))})()
     dummy_model = object()
     with pytest.raises(ValueError):
-        dr_value(df_missing, dummy_policy, dummy_model, target="accept")
+        dr_value(df_missing, dummy_policy, dummy_model, pA2, target="accept")


### PR DESCRIPTION
## Summary
- Remove propensity scores from synthetic logs and evaluate policies using estimated behavior probabilities
- Add `train_pi_hat`/`pi_hat_predict` to fit multinomial logistic propensity models
- Update IPS/SNIPS/DR estimators, examples, and docs to accept external propensity estimates

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c16e5df2f883328a99832bcd7d6487