### PR TITLE
Clarify advanced off-policy estimators

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 - **Replay** — учитывает только те логи, где B совпадает с A.
 - **IPS** — взвешивает отклики по отношению вероятностей выбора в B и A.
 - **SNIPS** — нормализует веса IPS для меньшей дисперсии.
-- **Doubly Robust** — комбинирует модель отклика и IPS; достаточно корректности хотя бы одной из них.
+- **Direct Method** — строит модель отклика и прогнозирует исходы под политикой B.
+- **Doubly Robust** — комбинирует Direct Method и IPS; достаточно корректности хотя бы одной из них.
 - **SN-DR** — нормализует поправку Doubly Robust, что снижает дисперсию.
 - **Switch-DR** — применяет IPS-поправку только при малых весах, иначе полагается на модель.
 
@@ -23,6 +24,7 @@
 - **Replay** — новая политика должна часто совпадать со старой, иначе большинство логов отбрасывается.
 - **IPS** — требует точного знания вероятностей действий в обеих политиках; большие веса увеличивают дисперсию.
 - **SNIPS** — нормализует веса IPS и снижает дисперсию, но остаётся чувствительным к ошибкам вероятностей и малым объёмам данных.
+- **Direct Method** — зависит от точности модели отклика и может смещаться вне обучающей области.
 - **Doubly Robust** — корректность достигается, если верна хотя бы модель отклика или пропенсити, но метод чувствителен к ошибкам обеих моделей и выбору клиппинга.
 - **SN-DR** — уменьшает дисперсию DR за счёт нормализации весов, но наследует его предположения.
 - **Switch-DR** — отбрасывает экстремальные веса, сочетая DM и DR, но выбор порога влияет на смещение.
@@ -91,6 +93,7 @@ from policyscope.estimators import (
     replay_value,
     ips_value,
     snips_value,
+    dm_value,
     dr_value,
     sndr_value,
     switch_dr_value,
@@ -107,10 +110,11 @@ mu_hat = train_mu_hat(df, target="accept")
 V_replay = replay_value(df, policyB, target="accept")
 V_ips, ess_ips, clip_ips = ips_value(df, piB_taken, pA_taken, target="accept")
 V_snips, ess_snips, clip_snips = snips_value(df, piB_taken, pA_taken, target="accept")
+V_dm = dm_value(df, policyB, mu_hat, target="accept")
 V_dr, ess_dr, clip_dr = dr_value(df, policyB, mu_hat, pA_taken, target="accept")
 V_sndr, ess_sndr, clip_sndr = sndr_value(df, policyB, mu_hat, pA_taken, target="accept")
 V_switch, ess_switch, share_switch = switch_dr_value(df, policyB, mu_hat, pA_taken, tau=20, target="accept")
-print(V_replay, V_ips, V_snips, V_dr, V_sndr, V_switch)
+print(V_replay, V_ips, V_snips, V_dm, V_dr, V_sndr, V_switch)
 ```
 
 ## Валидация оценок

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -59,6 +59,8 @@
     "- **SNIPS** — нормализует веса IPS, уменьшая дисперсию, но остаётся чувствителен к редким событиям.\n",
     "- **Direct Method (DM)** — строит модель исхода `μ(x,a)`; смещён, если модель неточна вне области наблюдений.\n",
     "- **Doubly Robust (DR)** — сочетает DM и IPS; достаточно корректности хотя бы одной из частей.\n",
+    "- **SN-DR** — нормализует поправку Doubly Robust, ограничивая влияние больших весов.\n",
+    "- **Switch-DR** — применяет IPS только при малых весах; иначе использует прогноз модели.\n",
     "\n",
     "См. подробности в работах [Dudík et al., 2011](https://arxiv.org/abs/1103.4601) и [Joachims et al., 2017](https://dl.acm.org/doi/10.1145/3018661.3018699)."
    ]
@@ -79,29 +81,13 @@
    "id": "903bd032",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-10T14:24:16.407671Z",
-     "iopub.status.busy": "2025-09-10T14:24:16.407264Z",
-     "iopub.status.idle": "2025-09-10T14:24:18.666106Z",
-     "shell.execute_reply": "2025-09-10T14:24:18.665045Z"
+     "iopub.execute_input": "2025-09-10T14:36:14.075032Z",
+     "iopub.status.busy": "2025-09-10T14:36:14.074770Z",
+     "iopub.status.idle": "2025-09-10T14:36:15.483213Z",
+     "shell.execute_reply": "2025-09-10T14:36:15.482506Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/workspace/OffPolicyLab/examples/../src/policyscope/estimators.py:127: SyntaxWarning: invalid escape sequence '\\h'\n",
-      "  \"\"\"Обучает модель пропенсити ``\\hat\\pi(a|x)``.\n",
-      "/workspace/OffPolicyLab/examples/../src/policyscope/estimators.py:144: SyntaxWarning: invalid escape sequence '\\h'\n",
-      "  \"\"\"Предсказывает ``\\hat\\pi(a|x)`` для всех действий.\"\"\"\n",
-      "/workspace/OffPolicyLab/examples/../src/policyscope/estimators.py:336: SyntaxWarning: invalid escape sequence '\\h'\n",
-      "  Обученная модель `\\hat\\mu(x,a)`.\n",
-      "/workspace/OffPolicyLab/examples/../src/policyscope/estimators.py:388: SyntaxWarning: invalid escape sequence '\\('\n",
-      "  \\(\\frac{1}{n} \\sum_i \\big[q^\\,(x_i, \\pi_B) + \\frac{w_i}{\\bar{w}} (r_i - q^\\,(x_i, a_i))\\big]\\).\n",
-      "/workspace/OffPolicyLab/examples/../src/policyscope/estimators.py:452: SyntaxWarning: invalid escape sequence '\\('\n",
-      "  Добавляет IPS-поправку только если вес \\(w_i = \\pi_B/\\pi_A\\) не превышает\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -234,10 +220,10 @@
    "id": "56c413b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-10T14:24:18.670268Z",
-     "iopub.status.busy": "2025-09-10T14:24:18.669704Z",
-     "iopub.status.idle": "2025-09-10T14:24:19.016542Z",
-     "shell.execute_reply": "2025-09-10T14:24:19.015221Z"
+     "iopub.execute_input": "2025-09-10T14:36:15.487263Z",
+     "iopub.status.busy": "2025-09-10T14:36:15.486826Z",
+     "iopub.status.idle": "2025-09-10T14:36:15.731889Z",
+     "shell.execute_reply": "2025-09-10T14:36:15.730964Z"
     }
    },
    "outputs": [
@@ -389,10 +375,10 @@
    "id": "7af49c10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-10T14:24:19.020176Z",
-     "iopub.status.busy": "2025-09-10T14:24:19.019675Z",
-     "iopub.status.idle": "2025-09-10T14:24:19.298183Z",
-     "shell.execute_reply": "2025-09-10T14:24:19.297060Z"
+     "iopub.execute_input": "2025-09-10T14:36:15.735503Z",
+     "iopub.status.busy": "2025-09-10T14:36:15.735182Z",
+     "iopub.status.idle": "2025-09-10T14:36:15.901320Z",
+     "shell.execute_reply": "2025-09-10T14:36:15.900488Z"
     }
    },
    "outputs": [
@@ -552,10 +538,10 @@
    "id": "cf99fac0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-10T14:24:19.302273Z",
-     "iopub.status.busy": "2025-09-10T14:24:19.301924Z",
-     "iopub.status.idle": "2025-09-10T14:24:53.172649Z",
-     "shell.execute_reply": "2025-09-10T14:24:53.171673Z"
+     "iopub.execute_input": "2025-09-10T14:36:15.904214Z",
+     "iopub.status.busy": "2025-09-10T14:36:15.903959Z",
+     "iopub.status.idle": "2025-09-10T14:36:40.815589Z",
+     "shell.execute_reply": "2025-09-10T14:36:40.814150Z"
     }
    },
    "outputs": [
@@ -564,12 +550,6 @@
      "output_type": "stream",
      "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -591,12 +571,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
@@ -612,8 +586,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -621,13 +593,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -649,12 +615,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
@@ -677,12 +637,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
@@ -705,12 +659,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
@@ -734,12 +682,6 @@
      "output_type": "stream",
      "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -762,12 +704,6 @@
      "output_type": "stream",
      "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -789,10 +725,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -817,10 +749,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -831,8 +759,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -850,8 +776,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -859,8 +783,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -878,8 +800,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -887,10 +807,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -918,10 +834,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -943,8 +855,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -955,8 +865,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -969,13 +877,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -983,8 +887,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -997,13 +899,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1023,13 +921,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1037,8 +931,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1049,8 +941,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1066,8 +956,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1075,10 +963,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1089,8 +973,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1113,8 +995,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1130,8 +1010,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1139,10 +1017,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1153,10 +1027,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1168,12 +1038,6 @@
      "output_type": "stream",
      "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1196,12 +1060,6 @@
      "output_type": "stream",
      "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1223,13 +1081,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1251,13 +1103,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1279,13 +1125,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1293,8 +1133,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1312,10 +1150,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1323,8 +1157,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1337,13 +1169,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1365,10 +1191,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
@@ -1384,6 +1206,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1405,19 +1229,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
@@ -1431,20 +1245,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1473,6 +1277,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1501,6 +1307,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1522,6 +1330,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1557,6 +1367,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1578,6 +1390,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1585,6 +1399,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1599,6 +1415,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1620,6 +1438,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1659,6 +1479,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1673,6 +1495,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1687,6 +1511,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1717,6 +1543,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1770,6 +1598,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1777,6 +1607,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1791,6 +1623,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1805,6 +1639,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1819,6 +1657,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1842,6 +1682,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1849,6 +1691,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1863,6 +1707,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1886,6 +1732,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1893,6 +1741,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1918,6 +1768,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1925,6 +1777,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1941,6 +1795,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1948,6 +1804,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -1955,6 +1813,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1969,6 +1829,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1983,6 +1847,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -1999,6 +1865,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2013,6 +1883,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2020,6 +1892,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2027,6 +1901,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2052,6 +1928,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2059,6 +1937,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2080,6 +1962,10 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2087,6 +1973,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2101,6 +1991,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2115,6 +2007,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2129,6 +2025,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2136,6 +2034,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2143,6 +2043,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2150,6 +2052,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2171,6 +2075,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2191,14 +2099,6 @@
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2213,6 +2113,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2233,16 +2135,6 @@
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2264,16 +2156,6 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
@@ -2291,14 +2173,6 @@
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2313,6 +2187,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2327,6 +2205,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2348,6 +2230,10 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2355,6 +2241,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2362,6 +2250,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2369,6 +2259,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2383,6 +2277,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2397,6 +2295,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2411,6 +2313,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2418,6 +2322,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2425,6 +2331,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2432,6 +2340,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2439,6 +2349,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2453,6 +2365,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2460,6 +2374,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2467,6 +2383,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2481,6 +2401,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2495,6 +2419,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2509,6 +2437,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2534,6 +2464,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2541,6 +2473,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2564,6 +2498,10 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2571,6 +2509,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2578,6 +2518,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2591,14 +2533,6 @@
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2620,6 +2554,8 @@
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2627,6 +2563,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2643,6 +2581,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
+      "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
+      "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
       "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/sklearn/linear_model/_logistic.py:1272: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.8. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
@@ -2716,10 +2660,10 @@
    "id": "5ff74380",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-10T14:24:53.175533Z",
-     "iopub.status.busy": "2025-09-10T14:24:53.175228Z",
-     "iopub.status.idle": "2025-09-10T14:24:54.170509Z",
-     "shell.execute_reply": "2025-09-10T14:24:54.169383Z"
+     "iopub.execute_input": "2025-09-10T14:36:40.818535Z",
+     "iopub.status.busy": "2025-09-10T14:36:40.818256Z",
+     "iopub.status.idle": "2025-09-10T14:36:41.478090Z",
+     "shell.execute_reply": "2025-09-10T14:36:41.477224Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary
- Document all estimators in order from simple to advanced
- Explain assumptions for SN-DR and Switch-DR in the tutorial
- Include `dm_value` in README usage example

## Testing
- `python -m flake8 src tests`
- `pytest`
- `python -m nbconvert --to notebook --execute examples/tutorial.ipynb --output tutorial.ipynb --output-dir examples`

------
https://chatgpt.com/codex/tasks/task_e_68c18c2e79e083328843f7b2d78a75b9