### PR TITLE
Make external nuisance reuse bootstrap-safe in compare_policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pip install -e .
 - `compare_policies(..., nuisance_bundle=...)` может принять заранее посчитанные nuisance-предсказания (опционально);
 - `compare_policies(..., use_crossfit=True)` строит OOF nuisance автоматически через внутренний helper;
 - покрываемые методы в cross-fitting mode: `ips/snips` (behavior nuisance), `dm/dr/sndr/switch_dr` (behavior + outcome nuisance).
+- migration note (bootstrap safety): при `with_ci=True` внешние nuisance-предсказания используются только для исходного point-estimate на оригинальных строках; в bootstrap-ресемплах они **не переиспользуются** (fallback к внутреннему fit), а факт fallback отражается в `inference_warnings` и `notes`.
 
 По умолчанию ничего менять не нужно: внутренний fit nuisance остаётся стандартным поведением.
 Важно: это практичный approximation-слой для снижения bias риска, а не гарантия «идеального» инференса.

--- a/src/policyscope/comparison.py
+++ b/src/policyscope/comparison.py
@@ -185,12 +185,35 @@ def compare_policies(
             action_space=action_space,
         )
 
+    external_nuisance_bootstrap_warning = (
+        "external_nuisance_not_reused_in_bootstrap_resamples_fallback_to_internal_nuisance_fit"
+    )
+    external_nuisance_observed = bool(
+        (nuisance_bundle is not None and (nuisance_bundle.behavior is not None or nuisance_bundle.outcome is not None))
+        or resolved_behavior is not None
+    )
+    fallback_triggered = {"value": False}
+    base_index = df.index.copy()
+
+    def _can_reuse_external_nuisance(part: pd.DataFrame) -> bool:
+        # Safe reuse policy: only for the exact original row identity and order.
+        # Bootstrap resamples may reorder, duplicate, or omit rows and must not
+        # reuse externally supplied nuisance predictions by position.
+        return part.index.equals(base_index)
+
     def point_on(part: pd.DataFrame) -> float:
+        can_reuse = _can_reuse_external_nuisance(part)
         behavior_preds = None
-        if nuisance_bundle is not None and nuisance_bundle.behavior is not None and len(part) == len(df):
-            behavior_preds = nuisance_bundle.behavior
-        elif resolved_behavior is not None and len(part) == len(df):
-            behavior_preds = resolved_behavior
+        outcome_preds = None
+        if can_reuse:
+            if nuisance_bundle is not None and nuisance_bundle.behavior is not None:
+                behavior_preds = nuisance_bundle.behavior
+            elif resolved_behavior is not None:
+                behavior_preds = resolved_behavior
+            if nuisance_bundle is not None and nuisance_bundle.outcome is not None:
+                outcome_preds = nuisance_bundle.outcome
+        elif external_nuisance_observed:
+            fallback_triggered["value"] = True
         return estimate_value(
             part,
             policyB,
@@ -202,11 +225,7 @@ def compare_policies(
             weight_clip=weight_clip,
             tau=tau,
             nuisance_behavior=behavior_preds,
-            nuisance_outcome=(
-                nuisance_bundle.outcome
-                if nuisance_bundle is not None and nuisance_bundle.outcome is not None and len(part) == len(df)
-                else None
-            ),
+            nuisance_outcome=outcome_preds,
             propensity_source=propensity_source,
             propensity_col=propensity_col,
         )
@@ -269,7 +288,10 @@ def compare_policies(
         n_boot=n_boot,
         alpha=alpha,
     ).to_dict()
-    notes = propensity_notes + tuple(diag.warnings) + tuple(inf.get("inference_warnings", []))
+    inference_warnings = tuple(inf.get("inference_warnings", []))
+    if fallback_triggered["value"]:
+        inference_warnings = inference_warnings + (external_nuisance_bootstrap_warning,)
+    notes = propensity_notes + tuple(diag.warnings) + inference_warnings
     return PolicyComparisonSummary(
         estimator=estimator,
         target=target,
@@ -285,7 +307,7 @@ def compare_policies(
         alpha=inf.get("alpha"),
         n_boot=inf.get("n_boot"),
         inference_method=inf.get("inference_method"),
-        inference_warnings=tuple(inf.get("inference_warnings", [])),
+        inference_warnings=inference_warnings,
         diagnostics=diag,
         notes=notes,
         propensity_source=diag.propensity_source or resolved_source,

--- a/src/policyscope/inference.py
+++ b/src/policyscope/inference.py
@@ -67,7 +67,7 @@ def _resample_df(
         return df.iloc[idx].copy()
     clusters = df[cluster_col].unique()
     sampled = rng.choice(clusters, size=len(clusters), replace=True)
-    return pd.concat([df[df[cluster_col] == c] for c in sampled], ignore_index=True)
+    return pd.concat([df[df[cluster_col] == c] for c in sampled]).copy()
 
 
 def _percentile_interval(samples: list[float], alpha: float) -> IntervalResult:

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from policyscope.comparison import (
     MultiMetricComparisonResult,
@@ -12,6 +13,7 @@ from policyscope.nuisance import CrossFitNuisanceBundle, generate_oof_behavior_p
 from policyscope.policies import make_policy
 from policyscope.report import decision_summary
 from policyscope.synthetic import SynthConfig, SyntheticRecommenderEnv
+import policyscope.comparison as comparison_mod
 
 
 def _prepare_env(seed: int = 100):
@@ -277,3 +279,99 @@ def test_logged_bandit_dataset_input_with_propensity_column():
     )
     assert summary.propensity_source == "logged"
     assert summary.propensity_column == "ps"
+
+
+@pytest.mark.parametrize(
+    "index_builder",
+    [
+        lambda n: np.arange(n - 1, -1, -1),  # reordered
+        lambda n: np.concatenate([np.arange(n - 1), [n - 2]]),  # duplicated row
+        lambda n: np.concatenate([np.arange(1, n), [1]]),  # omitted + duplicated row
+    ],
+)
+def test_bootstrap_does_not_reuse_external_nuisance_on_non_identical_rows(monkeypatch, index_builder):
+    logs, policyB = _prepare_env(112)
+    behavior = generate_oof_behavior_predictions(
+        logs,
+        policyB,
+        n_splits=3,
+        random_state=21,
+        feature_cols=["loyal", "age", "risk", "income"],
+        action_col="a_A",
+    )
+    bundle = CrossFitNuisanceBundle(behavior=behavior, n_splits=3)
+
+    original_estimate = comparison_mod.estimate_value
+    captured: list[tuple[bool, bool]] = []
+
+    def wrapped_estimate(*args, **kwargs):
+        captured.append((kwargs.get("nuisance_behavior") is not None, kwargs.get("nuisance_outcome") is not None))
+        return original_estimate(*args, **kwargs)
+
+    class _FakeInferenceResult:
+        def to_dict(self):
+            return {
+                "V_A": 0.0,
+                "V_B": 0.0,
+                "Delta": 0.0,
+                "V_A_CI": (0.0, 0.0),
+                "V_B_CI": (0.0, 0.0),
+                "Delta_CI": (0.0, 0.0),
+                "p_value": 1.0,
+                "is_significant": False,
+                "significance_rule": "centered_paired_bootstrap_p_value_lt_alpha",
+                "alpha": 0.05,
+                "n_boot": 3,
+                "inference_method": "paired_percentile_bootstrap+centered_delta_test",
+                "inference_warnings": [],
+            }
+
+    def fake_infer(df, estimator_pair, **kwargs):
+        idx = index_builder(len(df))
+        part = df.iloc[idx].copy()
+        estimator_pair(part)
+        return _FakeInferenceResult()
+
+    monkeypatch.setattr(comparison_mod, "estimate_value", wrapped_estimate)
+    monkeypatch.setattr(comparison_mod, "infer_policy_comparison_bootstrap", fake_infer)
+
+    summary = compare_policies(
+        logs,
+        policyB,
+        estimator="ips",
+        target="accept",
+        feature_cols=["loyal", "age", "risk", "income"],
+        action_col="a_A",
+        with_ci=True,
+        nuisance_bundle=bundle,
+        n_boot=3,
+    )
+
+    assert captured[0] == (True, False)
+    assert captured[-1] == (False, False)
+    assert "external_nuisance_not_reused_in_bootstrap_resamples_fallback_to_internal_nuisance_fit" in summary.inference_warnings
+    assert "external_nuisance_not_reused_in_bootstrap_resamples_fallback_to_internal_nuisance_fit" in summary.notes
+
+
+def test_with_ci_external_nuisance_fallback_warning_present():
+    logs, policyB = _prepare_env(113)
+    behavior = generate_oof_behavior_predictions(
+        logs,
+        policyB,
+        n_splits=3,
+        random_state=25,
+        feature_cols=["loyal", "age", "risk", "income"],
+        action_col="a_A",
+    )
+    summary = compare_policies(
+        logs,
+        policyB,
+        estimator="ips",
+        target="accept",
+        feature_cols=["loyal", "age", "risk", "income"],
+        action_col="a_A",
+        with_ci=True,
+        nuisance_bundle=CrossFitNuisanceBundle(behavior=behavior, n_splits=3),
+        n_boot=10,
+    )
+    assert "external_nuisance_not_reused_in_bootstrap_resamples_fallback_to_internal_nuisance_fit" in summary.inference_warnings


### PR DESCRIPTION
### Motivation
- Prevent unsafe positional reuse of externally-supplied/cross-fitted nuisance predictions during bootstrap inference, which previously used a fragile `len(part) == len(df)` check that can be satisfied by reordered/duplicated/omitted resamples.
- Ensure bootstrap inference is statistically honest by either re-fitting nuisances or explicitly disabling positional reuse, and surface that choice to users.

### Description
- Replace the `len(part) == len(df)` positional check with an explicit row-identity policy: external nuisance predictions are reused only when the resample `part` has the exact same `index` and order as the original `df` (checked via `part.index.equals(base_index)`); otherwise external nuisances are not reused and internal nuisance fitting is used for that resample. (changes in `src/policyscope/comparison.py`).
- Add a clear fallback marker `external_nuisance_not_reused_in_bootstrap_resamples_fallback_to_internal_nuisance_fit` that is appended to `inference_warnings` and `notes` when bootstrap resamples trigger the fallback. (changes in `src/policyscope/comparison.py`).
- Preserve row identity for cluster bootstrap resamples by avoiding index reset for concatenated cluster draws (removed `ignore_index=True` and ensure copy). (changes in `src/policyscope/inference.py`).
- Add targeted unit tests that would fail under the old buggy behavior: reordered resample, duplicated-row resample, omitted-row resample, and checks that `with_ci=True` with external nuisances produces the fallback warning and that the point estimate for the original dataset still reuses external nuisances. (changes in `tests/test_comparison.py`).
- Add a short migration note in `README.md` documenting the bootstrap-safe behavior and where the fallback is reported.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_comparison.py` and all tests in that file passed (15 passed). 
- Ran `PYTHONPATH=src pytest -q tests/test_bootstrap_report.py` and all tests passed (6 passed).
- Ran `PYTHONPATH=src pytest -q tests/test_docs_consistency.py` and all tests passed (4 passed).
- The new tests exercise reordered/duplicated/omitted resamples and assert the presence of the fallback warning; these tests passed in CI-local runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0479150883329590b17f5b0ea729)